### PR TITLE
Improve support for namespace lookup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,12 @@
 plugins {
   id 'com.nwalsh.gradle.saxon.saxon-gradle' version '0.9.3'
+  id 'com.nwalsh.gradle.relaxng.validate' version '0.0.6'
 }
 
 defaultTasks 'dist'
 
 import com.nwalsh.gradle.saxon.SaxonXsltTask
+import com.nwalsh.gradle.relaxng.validate.RelaxNGValidateTask
 
 task copy_data(type: Copy) {
   into "${buildDir}/xmlresolverdata-${version}"
@@ -16,10 +18,33 @@ task copy_data(type: Copy) {
 task make_data_catalog(type: SaxonXsltTask, dependsOn: ["copy_data"]) {
   input "${projectDir}/src/data/manifest.xml"
   output "${buildDir}/xmlresolverdata-${version}/catalog.xml"
+  outputs.file "${buildDir}/xmlresolverdata-${version}/cat-entities.xml"
+  outputs.file "${buildDir}/xmlresolverdata-${version}/cat-mathml2.xml"
+  outputs.file "${buildDir}/xmlresolverdata-${version}/cat-mathml3.xml"
+  outputs.file "${buildDir}/xmlresolverdata-${version}/cat-rddl.xml"
+  outputs.file "${buildDir}/xmlresolverdata-${version}/cat-svg.xml"
+  outputs.file "${buildDir}/xmlresolverdata-${version}/cat-xhtml.xml"
   stylesheet "${projectDir}/tools/make-catalog.xsl"
 }
 
-task dist(type: Zip, dependsOn: ["make_data_catalog"]) {
+task validate(dependsOn: ["make_data_catalog"]) {
+  // just some place to hang dependencies
+}
+
+make_data_catalog.outputs.files.each { xml ->
+  def fn = xml.toString()
+  def pos = fn.lastIndexOf("/")
+  fn = fn.substring(pos+1)
+  Task t = project.task("validate_${fn}", type: RelaxNGValidateTask) {
+    dependsOn "make_data_catalog"
+    input xml
+    output "${buildDir}/validated/${fn}"
+    schema "src/data/xmlcatalogs.org/schema/1.1/catalog.rng"
+  }
+  validate.dependsOn(t)
+}
+
+task dist(type: Zip, dependsOn: ["make_data_catalog", "validate"]) {
   from("$buildDir")
   exclude(["dist"])
   destinationDirectory = file("${buildDir}/dist")

--- a/src/data/manifest.xml
+++ b/src/data/manifest.xml
@@ -1294,4 +1294,30 @@
   <entry uri="root/www.w3.org/2007/schema-for-xslt20.xsd">
     <uri>https://www.w3.org/2007/schema-for-xslt20.xsd</uri>
   </entry>
+  <entry uri="root/xmlcatalogs.org/schema/1.1/catalog.xsd">
+    <uri>https://xmlcatalogs.org/schema/1.1/catalog.xsd</uri>
+    <uri>http://www.oasis-open.org/committees/entity/release/1.1/catalog.xsd</uri>
+    <namespace>urn:oasis:names:tc:entity:xmlns:tr9401:catalog</namespace>
+    <purpose>http://www.rddl.org/purposes#validation</purpose>
+    <nature>http://www.w3.org/2001/XMLSchema</nature>
+  </entry>
+  <entry uri="root/xmlcatalogs.org/schema/1.1/catalog.rnc">
+    <uri>https://xmlcatalogs.org/schema/1.1/catalog.rnc</uri>
+  </entry>
+  <entry uri="root/xmlcatalogs.org/schema/1.1/catalog.rng">
+    <uri>https://xmlcatalogs.org/schema/1.1/catalog.rng</uri>
+    <uri>http://www.oasis-open.org/committees/entity/release/1.1/catalog.rng</uri>
+    <namespace>urn:oasis:names:tc:entity:xmlns:tr9401:catalog</namespace>
+    <purpose>http://www.rddl.org/purposes#validation</purpose>
+    <nature>http://relaxng.org/ns/structure/1.0</nature>
+  </entry>
+  <entry uri="root/xmlcatalogs.org/schema/1.1/catalog.dtd">
+    <public>-//OASIS//DTD XML Catalogs V1.1//EN</public>
+    <uri>https://xmlcatalogs.org/schema/1.1/catalog.dtd</uri>
+    <uri>http://www.oasis-open.org/committees/entity/release/1.1/catalog.dtd</uri>
+    <namespace>urn:oasis:names:tc:entity:xmlns:tr9401:catalog</namespace>
+    <purpose>http://www.rddl.org/purposes#validation</purpose>
+    <nature>http://www.isi.edu/in-notes/iana/assignments/media-types/application/xml-dtd</nature>
+    <nature>https://www.iana.org/assignments/media-types/application/xml-dtd</nature>
+  </entry>
 </manifest>

--- a/src/data/manifest.xml
+++ b/src/data/manifest.xml
@@ -105,11 +105,12 @@
     <system>http://www.rddl.org/xhtml-symbol.ent</system>
   </entry>
   <entry uri="root/www.w3.org/1999/xlink.xsd">
-    <namespace>https://www.w3.org/1999/xlink</namespace>
     <uri>https://www.w3.org/1999/xlink.xsd</uri>
+    <namespace>https://www.w3.org/1999/xlink</namespace>
+    <purpose>http://www.rddl.org/purposes#validation</purpose>
+    <nature>http://www.w3.org/2001/XMLSchema</nature>
   </entry>
   <entry uri="root/www.w3.org/XML/2008/06/xlink.xsd">
-    <namespace>https://www.w3.org/1999/xlink</namespace>
     <uri>https://www.w3.org/XML/2008/06/xlink.xsd</uri>
   </entry>
   <entry uri="root/www.w3.org/2001/XMLSchema.dtd">
@@ -118,6 +119,9 @@
   </entry>
   <entry uri="root/www.w3.org/2001/XMLSchema.xsd">
     <uri>https://www.w3.org/2001/XMLSchema.xsd</uri>
+    <namespace>http://www.w3.org/2001/XMLSchema</namespace>
+    <purpose>http://www.rddl.org/purposes#validation</purpose>
+    <nature>http://www.w3.org/2001/XMLSchema</nature>
   </entry>
   <entry uri="root/www.w3.org/2001/datatypes.xsd">
     <public>-//W3C//DTD XSD 1.0 Datatypes//EN</public>
@@ -125,8 +129,10 @@
     <system>https://www.w3.org/2001/datatypes.xsd</system>
   </entry>
   <entry uri="root/www.w3.org/2001/xml.xsd">
-    <namespace>https://www.w3.org/XML/1998/namespace</namespace>
     <uri>https://www.w3.org/2001/xml.xsd</uri>
+    <namespace>https://www.w3.org/XML/1998/namespace</namespace>
+    <purpose>http://www.rddl.org/purposes#validation</purpose>
+    <nature>http://www.w3.org/2001/XMLSchema</nature>
   </entry>
   <entry uri="root/www.w3.org/2002/xmlspec/dtd/2.10/xmlspec.dtd">
     <public>-//W3C//DTD Specification V2.10//EN</public>

--- a/src/data/xmlcatalogs.org/schema/1.1/catalog.dtd
+++ b/src/data/xmlcatalogs.org/schema/1.1/catalog.dtd
@@ -1,0 +1,174 @@
+<!-- $Id: catalog.dtd,v 1.14 2005/04/13 20:47:06 ndw Exp $ -->
+
+<!ENTITY % pubIdChars "CDATA">
+<!ENTITY % publicIdentifier "%pubIdChars;">
+<!ENTITY % partialPublicIdentifier "%pubIdChars;">
+<!ENTITY % uriReference "CDATA">
+<!ENTITY % string "CDATA">
+<!ENTITY % systemOrPublic "(system|public)">
+
+<!ENTITY % p "">
+<!ENTITY % s "">
+<!ENTITY % nsdecl "xmlns%s;">
+
+<!ENTITY % catalog "%p;catalog">
+<!ENTITY % public "%p;public">
+<!ENTITY % system "%p;system">
+<!ENTITY % uri "%p;uri">
+<!ENTITY % rewriteSystem "%p;rewriteSystem">
+<!ENTITY % rewriteURI "%p;rewriteURI">
+<!ENTITY % systemSuffix "%p;systemSuffix">
+<!ENTITY % uriSuffix "%p;uriSuffix">
+<!ENTITY % delegatePublic "%p;delegatePublic">
+<!ENTITY % delegateSystem "%p;delegateSystem">
+<!ENTITY % delegateURI "%p;delegateURI">
+<!ENTITY % nextCatalog "%p;nextCatalog">
+<!ENTITY % group "%p;group">
+
+<!ENTITY % local.catalog.mix "">
+<!ENTITY % local.catalog.attribs "">
+
+<!ELEMENT %catalog; (%public;|%system;|%uri;
+                     |%rewriteSystem;|%rewriteURI;
+                     |%systemSuffix;|%uriSuffix;
+                     |%delegatePublic;|%delegateSystem;|%delegateURI;
+                     |%nextCatalog;|%group; %local.catalog.mix;)+>
+<!ATTLIST %catalog;
+        %nsdecl;        %uriReference;          #FIXED
+                'urn:oasis:names:tc:entity:xmlns:xml:catalog'
+        id              ID                      #IMPLIED
+        prefer          %systemOrPublic;        #IMPLIED
+        xml:base        %uriReference;          #IMPLIED
+        %local.catalog.attribs;
+>
+
+<!ENTITY % local.public.attribs "">
+
+<!ELEMENT %public; EMPTY>
+<!ATTLIST %public;
+        id              ID                      #IMPLIED
+        publicId        %publicIdentifier;      #REQUIRED
+        uri             %uriReference;          #REQUIRED
+        xml:base        %uriReference;          #IMPLIED
+        %local.public.attribs;
+>
+
+<!ENTITY % local.system.attribs "">
+
+<!ELEMENT %system; EMPTY>
+<!ATTLIST %system;
+        id              ID                      #IMPLIED
+        systemId        %string;                #REQUIRED
+        uri             %uriReference;          #REQUIRED
+        xml:base        %uriReference;          #IMPLIED
+        %local.system.attribs;
+>
+
+<!ENTITY % local.uri.attribs "">
+
+<!ELEMENT %uri; EMPTY>
+<!ATTLIST %uri;
+        id              ID                      #IMPLIED
+        name            %string;                #REQUIRED
+        uri             %uriReference;          #REQUIRED
+        xml:base        %uriReference;          #IMPLIED
+        %local.uri.attribs;
+>
+
+<!ENTITY % local.rewriteSystem.attribs "">
+
+<!ELEMENT %rewriteSystem; EMPTY>
+<!ATTLIST %rewriteSystem;
+        id              ID                      #IMPLIED
+        systemIdStartString     %string;        #REQUIRED
+        rewritePrefix           %string;                #REQUIRED
+        %local.rewriteSystem.attribs;
+>
+
+<!ENTITY % local.rewriteURI.attribs "">
+
+<!ELEMENT %rewriteURI; EMPTY>
+<!ATTLIST %rewriteURI;
+        id              ID                      #IMPLIED
+        uriStartString  %string;                #REQUIRED
+        rewritePrefix   %string;                #REQUIRED
+        %local.rewriteURI.attribs;
+>
+
+<!ENTITY % local.systemSuffix.attribs "">
+
+<!ELEMENT %systemSuffix; EMPTY>
+<!ATTLIST %systemSuffix;
+        id              ID                      #IMPLIED
+        systemIdSuffix          %string;        #REQUIRED
+        uri                     %string;        #REQUIRED
+        %local.systemSuffix.attribs;
+>
+
+<!ENTITY % local.uriSuffix.attribs "">
+
+<!ELEMENT %uriSuffix; EMPTY>
+<!ATTLIST %uriSuffix;
+        id              ID                      #IMPLIED
+        uriSuffix               %string;        #REQUIRED
+        uri                     %string;        #REQUIRED
+        %local.uriSuffix.attribs;
+>
+
+<!ENTITY % local.delegatePublic.attribs "">
+
+<!ELEMENT %delegatePublic; EMPTY>
+<!ATTLIST %delegatePublic;
+        id              ID                      #IMPLIED
+        publicIdStartString     %partialPublicIdentifier;       #REQUIRED
+        catalog         %uriReference;          #REQUIRED
+        xml:base        %uriReference;          #IMPLIED
+        %local.delegatePublic.attribs;
+>
+
+<!ENTITY % local.delegateSystem.attribs "">
+
+<!ELEMENT %delegateSystem; EMPTY>
+<!ATTLIST %delegateSystem;
+        id              ID                      #IMPLIED
+        systemIdStartString     %string;        #REQUIRED
+        catalog         %uriReference;          #REQUIRED
+        xml:base        %uriReference;          #IMPLIED
+        %local.delegateSystem.attribs;
+>
+
+<!ENTITY % local.delegateURI.attribs "">
+
+<!ELEMENT %delegateURI; EMPTY>
+<!ATTLIST %delegateURI;
+        id              ID                      #IMPLIED
+        uriStartString  %string;                #REQUIRED
+        catalog         %uriReference;          #REQUIRED
+        xml:base        %uriReference;          #IMPLIED
+        %local.delegateURI.attribs;
+>
+
+<!ENTITY % local.nextCatalog.attribs "">
+
+<!ELEMENT %nextCatalog; EMPTY>
+<!ATTLIST %nextCatalog;
+        id              ID                      #IMPLIED
+        catalog         %uriReference;          #REQUIRED
+        xml:base        %uriReference;          #IMPLIED
+        %local.nextCatalog.attribs;
+>
+
+<!ENTITY % local.group.mix "">
+<!ENTITY % local.group.attribs "">
+
+<!ELEMENT %group; (%public;|%system;|%uri;
+                   |%rewriteSystem;|%rewriteURI;
+                   |%systemSuffix;|%uriSuffix;
+                   |%delegatePublic;|%delegateSystem;|%delegateURI;
+                   |%nextCatalog; %local.group.mix;)+>
+<!ATTLIST %group;
+        id              ID                      #IMPLIED
+        prefer          %systemOrPublic;        #IMPLIED
+        xml:base        %uriReference;          #IMPLIED
+        %local.group.attribs;
+>

--- a/src/data/xmlcatalogs.org/schema/1.1/catalog.rnc
+++ b/src/data/xmlcatalogs.org/schema/1.1/catalog.rnc
@@ -1,0 +1,131 @@
+namespace local = ""
+default namespace ns1 = "urn:oasis:names:tc:entity:xmlns:xml:catalog"
+
+# $Id: catalog.rng,v 1.4 2005/02/25 18:54:25 ndw Exp $
+start = Catalog
+pubIdChars =
+  xsd:string { pattern = "[a-zA-Z0-9\-'\(\)+,./:=?;!*#@$_% ]*" }
+publicIdentifier = pubIdChars
+partialPublicIdentifier = pubIdChars
+systemOrPublic = "system" | "public"
+uriReference = xsd:anyURI
+OptionalAttributes =
+  attribute id { xsd:ID }?,
+  attribute * - (local:* | ns1:*) { text }*
+PreferAttribute = attribute prefer { systemOrPublic }
+Catalog =
+  element catalog {
+    OptionalAttributes,
+    PreferAttribute?,
+    (Group
+     | Public
+     | System
+     | Uri
+     | RewriteSystem
+     | RewriteURI
+     | SystemSuffix
+     | UriSuffix
+     | DelegatePublic
+     | DelegateSystem
+     | DelegateURI
+     | NextCatalog
+     | AnyOtherElement)+
+  }
+Group =
+  element group {
+    OptionalAttributes,
+    PreferAttribute?,
+    (Public
+     | System
+     | Uri
+     | RewriteSystem
+     | RewriteURI
+     | SystemSuffix
+     | UriSuffix
+     | DelegatePublic
+     | DelegateSystem
+     | DelegateURI
+     | NextCatalog
+     | AnyOtherElement)+
+  }
+Public =
+  element public {
+    attribute publicId { publicIdentifier },
+    attribute uri { uriReference },
+    OptionalAttributes,
+    empty
+  }
+System =
+  element system {
+    attribute systemId { text },
+    attribute uri { uriReference },
+    OptionalAttributes,
+    empty
+  }
+Uri =
+  element uri {
+    attribute name { text },
+    attribute uri { uriReference },
+    OptionalAttributes,
+    empty
+  }
+RewriteSystem =
+  element rewriteSystem {
+    attribute systemIdStartString { text },
+    attribute rewritePrefix { text },
+    OptionalAttributes,
+    empty
+  }
+RewriteURI =
+  element rewriteURI {
+    attribute uriStartString { text },
+    attribute rewritePrefix { text },
+    OptionalAttributes,
+    empty
+  }
+SystemSuffix =
+  element systemSuffix {
+    attribute systemIdSuffix { text },
+    attribute uri { uriReference },
+    OptionalAttributes,
+    empty
+  }
+UriSuffix =
+  element uriSuffix {
+    attribute uriSuffix { text },
+    attribute uri { uriReference },
+    OptionalAttributes,
+    empty
+  }
+DelegatePublic =
+  element delegatePublic {
+    attribute publicIdStartString { text },
+    attribute catalog { text },
+    OptionalAttributes,
+    empty
+  }
+DelegateSystem =
+  element delegateSystem {
+    attribute systemIdStartString { text },
+    attribute catalog { text },
+    OptionalAttributes,
+    empty
+  }
+DelegateURI =
+  element delegateURI {
+    attribute uriStartString { text },
+    attribute catalog { text },
+    OptionalAttributes,
+    empty
+  }
+NextCatalog =
+  element nextCatalog {
+    attribute catalog { text },
+    OptionalAttributes,
+    empty
+  }
+AnyOtherElement =
+  element * - (local:* | ns1:*) {
+    attribute * { text }*,
+    (text | AnyOtherElement)
+  }

--- a/src/data/xmlcatalogs.org/schema/1.1/catalog.rng
+++ b/src/data/xmlcatalogs.org/schema/1.1/catalog.rng
@@ -1,0 +1,243 @@
+<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         ns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+  <!-- $Id: catalog.rng,v 1.4 2005/02/25 18:54:25 ndw Exp $ -->
+
+  <start>
+    <choice>
+      <ref name="Catalog"/>
+    </choice>
+  </start>
+
+  <define name="pubIdChars">
+    <data type="string">
+      <param name="pattern">[a-zA-Z0-9\-'\(\)+,./:=?;!*#@$_% ]*</param>
+    </data>
+  </define>
+
+  <define name="publicIdentifier">
+    <ref name="pubIdChars"/>
+  </define>
+
+  <define name="partialPublicIdentifier">
+    <ref name="pubIdChars"/>
+  </define>
+
+  <define name="systemOrPublic">
+    <choice>
+      <value>system</value>
+      <value>public</value>
+    </choice>
+  </define>
+
+  <define name="uriReference">
+    <data type="anyURI"/>
+  </define>
+
+  <define name="OptionalAttributes">
+    <optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+    </optional>
+    <zeroOrMore>
+      <attribute>
+        <anyName>
+          <except>
+            <nsName ns=""/>
+            <nsName/>
+           </except>
+         </anyName>
+      </attribute>
+    </zeroOrMore>
+  </define>
+
+  <define name="PreferAttribute">
+    <attribute name="prefer">
+      <ref name="systemOrPublic"/>
+    </attribute>
+  </define>
+
+  <define name="Catalog">
+    <element name="catalog">
+      <ref name="OptionalAttributes"/>
+      <optional>
+        <ref name="PreferAttribute"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="Group"/>
+          <ref name="Public"/>
+          <ref name="System"/>
+          <ref name="Uri"/>
+          <ref name="RewriteSystem"/>
+          <ref name="RewriteURI"/>
+          <ref name="SystemSuffix"/>
+          <ref name="UriSuffix"/>
+          <ref name="DelegatePublic"/>
+          <ref name="DelegateSystem"/>
+          <ref name="DelegateURI"/>
+          <ref name="NextCatalog"/>
+          <ref name="AnyOtherElement"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <define name="Group">
+    <element name="group">
+      <ref name="OptionalAttributes"/>
+      <optional>
+        <ref name="PreferAttribute"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="Public"/>
+          <ref name="System"/>
+          <ref name="Uri"/>
+          <ref name="RewriteSystem"/>
+          <ref name="RewriteURI"/>
+          <ref name="SystemSuffix"/>
+          <ref name="UriSuffix"/>
+          <ref name="DelegatePublic"/>
+          <ref name="DelegateSystem"/>
+          <ref name="DelegateURI"/>
+          <ref name="NextCatalog"/>
+          <ref name="AnyOtherElement"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <define name="Public">
+    <element name="public">
+      <attribute name="publicId">
+        <ref name="publicIdentifier"/>
+      </attribute>
+      <attribute name="uri">
+        <ref name="uriReference"/>
+      </attribute>
+      <ref name="OptionalAttributes"/>
+      <empty/>
+    </element>
+  </define>
+
+  <define name="System">
+    <element name="system">
+      <attribute name="systemId"/>
+      <attribute name="uri">
+        <ref name="uriReference"/>
+      </attribute>
+      <ref name="OptionalAttributes"/>
+      <empty/>
+    </element>
+  </define>
+
+  <define name="Uri">
+    <element name="uri">
+      <attribute name="name"/>
+      <attribute name="uri">
+        <ref name="uriReference"/>
+      </attribute>
+      <ref name="OptionalAttributes"/>
+      <empty/>
+    </element>
+  </define>
+
+  <define name="RewriteSystem">
+    <element name="rewriteSystem">
+      <attribute name="systemIdStartString"/>
+      <attribute name="rewritePrefix"/>
+      <ref name="OptionalAttributes"/>
+      <empty/>
+    </element>
+  </define>
+
+  <define name="RewriteURI">
+    <element name="rewriteURI">
+      <attribute name="uriStartString"/>
+      <attribute name="rewritePrefix"/>
+      <ref name="OptionalAttributes"/>
+      <empty/>
+    </element>
+  </define>
+
+  <define name="SystemSuffix">
+    <element name="systemSuffix">
+      <attribute name="systemIdSuffix"/>
+      <attribute name="uri">
+        <ref name="uriReference"/>
+      </attribute>
+      <ref name="OptionalAttributes"/>
+      <empty/>
+    </element>
+  </define>
+
+  <define name="UriSuffix">
+    <element name="uriSuffix">
+      <attribute name="uriSuffix"/>
+      <attribute name="uri">
+        <ref name="uriReference"/>
+      </attribute>
+      <ref name="OptionalAttributes"/>
+      <empty/>
+    </element>
+  </define>
+
+  <define name="DelegatePublic">
+    <element name="delegatePublic">
+      <attribute name="publicIdStartString"/>
+      <attribute name="catalog"/>
+      <ref name="OptionalAttributes"/>
+      <empty/>
+    </element>
+  </define>
+
+  <define name="DelegateSystem">
+    <element name="delegateSystem">
+      <attribute name="systemIdStartString"/>
+      <attribute name="catalog"/>
+      <ref name="OptionalAttributes"/>
+      <empty/>
+    </element>
+  </define>
+
+  <define name="DelegateURI">
+    <element name="delegateURI">
+      <attribute name="uriStartString"/>
+      <attribute name="catalog"/>
+      <ref name="OptionalAttributes"/>
+      <empty/>
+    </element>
+  </define>
+
+  <define name="NextCatalog">
+    <element name="nextCatalog">
+      <attribute name="catalog"/>
+      <ref name="OptionalAttributes"/>
+      <empty/>
+    </element>
+  </define>
+
+  <define name="AnyOtherElement">
+    <element>
+      <anyName>
+        <except>
+          <nsName ns=""/>
+          <nsName/>
+        </except>
+      </anyName>
+      <zeroOrMore>
+        <attribute>
+          <anyName/>
+        </attribute>
+      </zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="AnyOtherElement"/>
+      </choice>
+    </element>
+  </define>
+</grammar>

--- a/src/data/xmlcatalogs.org/schema/1.1/catalog.xsd
+++ b/src/data/xmlcatalogs.org/schema/1.1/catalog.xsd
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:er="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+           targetNamespace="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+           elementFormDefault="qualified">
+
+  <!-- $Id: catalog.xsd,v 1.15 2005/10/07 13:27:08 ndw Exp $ -->
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"/>
+
+  <xs:simpleType name="pubIdChars">
+    <!-- A string of the characters defined as pubIdChar in production 13
+         of the Second Edition of the XML 1.0 Recommendation. Does not include
+         the whitespace characters because they're normalized by XML parsing. -->
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-zA-Z0-9\-'\(\)+,./:=?;!*#@$_%]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="publicIdentifier">
+    <xs:restriction base="er:pubIdChars"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="partialPublicIdentifier">
+    <xs:restriction base="er:pubIdChars"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="systemOrPublic">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="system"/>
+      <xs:enumeration value="public"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- The global attribute xml:base is not explicitly declared; -->
+  <!-- it is allowed by the anyAttribute declarations. -->
+
+  <xs:complexType name="catalog">
+    <xs:choice minOccurs="1" maxOccurs="unbounded">
+      <xs:element ref="er:public"/>
+      <xs:element ref="er:system"/>
+      <xs:element ref="er:uri"/>
+      <xs:element ref="er:rewriteSystem"/>
+      <xs:element ref="er:rewriteURI"/>
+      <xs:element ref="er:uriSuffix"/>
+      <xs:element ref="er:systemSuffix"/>
+      <xs:element ref="er:delegatePublic"/>
+      <xs:element ref="er:delegateSystem"/>
+      <xs:element ref="er:delegateURI"/>
+      <xs:element ref="er:nextCatalog"/>
+      <xs:element ref="er:group"/>
+      <xs:any namespace="##other" processContents="skip"/>
+    </xs:choice>
+    <xs:attribute name="id" type="xs:ID"/>
+    <xs:attribute name="prefer" type="er:systemOrPublic"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+
+  <xs:complexType name="public">
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="publicId" type="er:publicIdentifier"
+                       use="required"/>
+        <xs:attribute name="uri" type="xs:anyURI" use="required"/>
+        <xs:attribute name="id" type="xs:ID"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="system">
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="systemId" type="xs:string"
+                       use="required"/>
+        <xs:attribute name="uri" type="xs:anyURI" use="required"/>
+        <xs:attribute name="id" type="xs:ID"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="uri">
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="name" type="xs:anyURI"
+                       use="required"/>
+        <xs:attribute name="uri" type="xs:anyURI" use="required"/>
+        <xs:attribute name="id" type="xs:ID"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="rewriteSystem">
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="systemIdStartString"
+                       type="xs:string"
+                       use="required"/>
+        <xs:attribute name="rewritePrefix" type="xs:string" use="required"/>
+        <xs:attribute name="id" type="xs:ID"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="rewriteURI">
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="uriStartString"
+                       type="xs:string"
+                       use="required"/>
+        <xs:attribute name="rewritePrefix" type="xs:string" use="required"/>
+        <xs:attribute name="id" type="xs:ID"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="systemSuffix">
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="systemIdSuffix"
+                       type="xs:string"
+                       use="required"/>
+        <xs:attribute name="uri" type="xs:anyURI" use="required"/>
+        <xs:attribute name="id" type="xs:ID"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="uriSuffix">
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="uriSuffix"
+                       type="xs:string"
+                       use="required"/>
+        <xs:attribute name="uri" type="xs:anyURI" use="required"/>
+        <xs:attribute name="id" type="xs:ID"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="delegatePublic">
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="publicIdStartString"
+                       type="er:partialPublicIdentifier"
+                       use="required"/>
+        <xs:attribute name="catalog" type="xs:anyURI" use="required"/>
+        <xs:attribute name="id" type="xs:ID"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="delegateSystem">
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="systemIdStartString"
+                       type="xs:string"
+                       use="required"/>
+        <xs:attribute name="catalog" type="xs:anyURI" use="required"/>
+        <xs:attribute name="id" type="xs:ID"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="delegateURI">
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="uriStartString"
+                       type="xs:string"
+                       use="required"/>
+        <xs:attribute name="catalog" type="xs:anyURI" use="required"/>
+        <xs:attribute name="id" type="xs:ID"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="nextCatalog">
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="catalog" type="xs:anyURI" use="required"/>
+        <xs:attribute name="id" type="xs:ID"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="group">
+    <xs:choice minOccurs="1" maxOccurs="unbounded">
+      <xs:element ref="er:public"/>
+      <xs:element ref="er:system"/>
+      <xs:element ref="er:uri"/>
+      <xs:element ref="er:rewriteSystem"/>
+      <xs:element ref="er:rewriteURI"/>
+      <xs:element ref="er:uriSuffix"/>
+      <xs:element ref="er:systemSuffix"/>
+      <xs:element ref="er:delegatePublic"/>
+      <xs:element ref="er:delegateSystem"/>
+      <xs:element ref="er:delegateURI"/>
+      <xs:element ref="er:nextCatalog"/>
+      <xs:any namespace="##other" processContents="skip"/>
+    </xs:choice>
+    <xs:attribute name="prefer" type="er:systemOrPublic"/>
+    <xs:attribute name="id" type="xs:ID"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+
+  <xs:element name="catalog" type="er:catalog"/>
+  <xs:element name="public" type="er:public"/>
+  <xs:element name="system" type="er:system"/>
+  <xs:element name="uri" type="er:uri"/>
+  <xs:element name="rewriteSystem" type="er:rewriteSystem"/>
+  <xs:element name="rewriteURI" type="er:rewriteURI"/>
+  <xs:element name="systemSuffix" type="er:systemSuffix"/>
+  <xs:element name="uriSuffix" type="er:uriSuffix"/>
+  <xs:element name="delegatePublic" type="er:delegatePublic"/>
+  <xs:element name="delegateSystem" type="er:delegateSystem"/>
+  <xs:element name="delegateURI" type="er:delegateURI"/>
+  <xs:element name="nextCatalog" type="er:nextCatalog"/>
+  <xs:element name="group" type="er:group"/>
+
+</xs:schema>

--- a/tools/make-catalog.xsl
+++ b/tools/make-catalog.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                xmlns:rddl="http://www.rddl.org/"
                 xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
                 exclude-result-prefixes="map xs"
                 version="3.0">
@@ -11,7 +12,7 @@
 
 <xsl:template match="/">
   <xsl:variable name="entries" as="element()*">
-    <xsl:apply-templates select="//public|//system|//uri"
+    <xsl:apply-templates select="//public|//system|//uri|//namespace"
                          mode="catalog-entry"/>
   </xsl:variable>
   <xsl:variable name="subset" select="()"/>
@@ -225,5 +226,23 @@
 <xsl:template match="uri" mode="catalog-entry">
   <uri name="{.}" uri="{substring-after(../@uri, 'root/')}"/>
 </xsl:template>
+
+<xsl:template match="namespace" mode="catalog-entry">
+  <xsl:if test="count(../purpose) gt 1">
+    <xsl:message terminate="yes">At most purpose is allowed</xsl:message>
+  </xsl:if>
+
+  <xsl:variable name="namespace" select="string(.)"/>
+  <xsl:variable name="uri" select="substring-after(../@uri, 'root/')"/>
+
+  <xsl:for-each select="../purpose">
+    <xsl:variable name="purpose" select="string(.)"/>
+    <xsl:for-each select="../nature">
+      <uri name="{$namespace}" uri="{$uri}"
+           rddl:purpose="{$purpose}"
+           rddl:nature="{string(.)}"/>
+    </xsl:for-each>
+  </xsl:for-each>
+</xsl:template>  
 
 </xsl:stylesheet>


### PR DESCRIPTION
1. If a URI has a namespace with a nature and purpose in the manifest, generate a `uri` entry decorated with `rddl:nature` and `rddl:purpose` so that the `NamespaceResolver` will work
2. Added OASIS XML Catalog schemas to the collection
3. Updated the build script so that the generated catalogs are validated against the XML Catalog schema.