### PR TITLE
fully qualify path to the catalog schema

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ make_data_catalog.outputs.files.each { xml ->
     dependsOn "make_data_catalog"
     input xml
     output "${buildDir}/validated/${fn}"
-    schema "src/data/xmlcatalogs.org/schema/1.1/catalog.rng"
+    schema "${projectDir}/src/data/xmlcatalogs.org/schema/1.1/catalog.rng"
   }
   validate.dependsOn(t)
 }


### PR DESCRIPTION
Without this change, validation of the catalog data files kept failing on my machine:

```
ludwigc$ ./gradlew dist --rerun-tasks

> Task :validate_cat-entities.xml FAILED
error: file not found: /Users/ludwigc/.gradle/daemon/7.1.1/src/data/xmlcatalogs.org/schema/1.1/catalog.rng (No such file or directory)

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':validate_cat-entities.xml'.
> java.io.FileNotFoundException: /Users/ludwigc/.gradle/daemon/7.1.1/src/data/xmlcatalogs.org/schema/1.1/catalog.rng (No such file or directory)

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
4 actionable tasks: 4 executed
```

I guess this is a consequence of https://github.com/gradle/gradle/issues/5187, but I did not dig deeper.