### PR TITLE
Make source path explicit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202111-02
 
     java:
       version: oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ make_data_catalog.outputs.files.each { xml ->
     dependsOn "make_data_catalog"
     input xml
     output "${buildDir}/validated/${fn}"
-    schema "src/data/xmlcatalogs.org/schema/1.1/catalog.rng"
+    schema "${projectDir}/src/data/xmlcatalogs.org/schema/1.1/catalog.rng"
   }
   validate.dependsOn(t)
 }


### PR DESCRIPTION
There seems to be a build problem in CI that *I think* is related to the schema source path not having an explicit `projectDir` prefix.